### PR TITLE
fix: validar nombres archivos

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,7 @@ class Config(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(60)
 
     UPLOAD_DIR: str = "uploads"
+    TAMAÑO_LIMITE: int = 1000 * 1024 * 1024  # 1GB
 
     @computed_field
     @property

--- a/backend/app/repositories/file_repo.py
+++ b/backend/app/repositories/file_repo.py
@@ -18,3 +18,7 @@ def get_file_by_id_and_user(id: uuid.UUID, usuario: User, db: Session) -> File |
 
 def get_files_user(usuario: User, db: Session) -> list[File]:
     return db.query(File).filter_by(id_usuario=usuario.id).all()
+
+
+def get_file_original_name(nombre_original: str, usuario: User, db: Session) -> File | None:
+    return db.query(File).filter_by(nombre_original=nombre_original, id_usuario=usuario.id).first()

--- a/backend/app/routes/file_routes.py
+++ b/backend/app/routes/file_routes.py
@@ -7,7 +7,7 @@ from app.database.db import get_db
 
 from app.models.user import User
 from app.services.file_services import guardar_archivo, obtener_archivos_usuario, obtener_archivo_id
-from app.models.exceptions import ArchivoNoEncontradoException, TamañoExcedidoException, IdYaUsadaException
+from app.models.exceptions import ArchivoNoEncontradoException, TamañoExcedidoException, IdYaUsadaException, NombreYaUsadoException
 from app.schemas.file_schemas import FileBase, FileResponse
 from app.services.auth_services import get_current_user
 
@@ -40,6 +40,8 @@ async def upload_file(file_upload: list[UploadFile] = File(...), db: Session = D
         raise HTTPException(413, str(e1))
     except IdYaUsadaException as e2:
         raise HTTPException(409, str(e2))
+    except NombreYaUsadoException as e3:
+        raise HTTPException(409, str(e3))
 
 
 @file_router.get("", response_model=list[FileBase])

--- a/backend/app/services/file_services.py
+++ b/backend/app/services/file_services.py
@@ -12,7 +12,7 @@ from app.config import config
 
 UPLOAD_DIR = Path(config.UPLOAD_DIR)
 UPLOAD_DIR.mkdir(exist_ok=True)
-TAMAÑO_LIMITE = 1000 * 1024 * 1024  # Lo limito a 1GB de momento
+TAMAÑO_LIMITE = config.TAMAÑO_LIMITE  # Lo limito a 1GB de momento
 
 
 def obtener_archivo_id(id: uuid.UUID, usuario: User, db: Session) -> File:
@@ -53,7 +53,8 @@ def añadir_archivo_db(nombre_original: str, tamaño: int, db: Session, usuario:
     IdYaUsadaException, NombreYaUsadoException
     """
     if get_file_original_name(nombre_original=nombre_original, usuario=usuario, db=db):
-        raise NombreYaUsadoException(f"Ya hay un archivo con el nombre '{nombre_original}'. Cambia el nombre")
+        raise NombreYaUsadoException(
+            f"Ya hay un archivo con el nombre '{nombre_original}'. Cambia el nombre")
 
     id: uuid.UUID = uuid.uuid4()
 

--- a/backend/app/services/file_services.py
+++ b/backend/app/services/file_services.py
@@ -3,10 +3,10 @@ import uuid
 
 from fastapi import UploadFile
 from sqlalchemy.orm import Session
-from app.models.exceptions import TamañoExcedidoException, ArchivoNoEncontradoException, IdYaUsadaException
+from app.models.exceptions import TamañoExcedidoException, ArchivoNoEncontradoException, IdYaUsadaException, NombreYaUsadoException
 from app.models.file import File
 from app.models.user import User
-from app.repositories.file_repo import insert_file_db, get_file_by_id_and_user, get_files_user
+from app.repositories.file_repo import insert_file_db, get_file_by_id_and_user, get_files_user, get_file_original_name
 
 from app.config import config
 
@@ -31,7 +31,7 @@ def obtener_archivo_id(id: uuid.UUID, usuario: User, db: Session) -> File:
 
 async def guardar_archivo(file_upload: UploadFile, db: Session, usuario: User) -> File:
     """
-    TamañoExcedidoException, IdYaUsadaException
+    TamañoExcedidoException, IdYaUsadaException, NombreYaUsadoException
     """
     data = await file_upload.read()
 
@@ -50,12 +50,15 @@ async def guardar_archivo(file_upload: UploadFile, db: Session, usuario: User) -
 
 def añadir_archivo_db(nombre_original: str, tamaño: int, db: Session, usuario: User) -> tuple[File, str]:
     """
-    IdYaUsadaException
+    IdYaUsadaException, NombreYaUsadoException
     """
+    if get_file_original_name(nombre_original=nombre_original, usuario=usuario, db=db):
+        raise NombreYaUsadoException(f"Ya hay un archivo con el nombre '{nombre_original}'. Cambia el nombre")
+
     id: uuid.UUID = uuid.uuid4()
 
     # Por si se genera un UUID ya usado
-    if (get_file_by_id_and_user(id=id, usuario=usuario, db=db)):
+    if get_file_by_id_and_user(id=id, usuario=usuario, db=db):
         raise IdYaUsadaException(
             f"Ya se ha usado la ID {id}. Vuelve a subir el archivo")
 

--- a/backend/tests/files/test_upload.py
+++ b/backend/tests/files/test_upload.py
@@ -3,6 +3,7 @@ import uuid
 from fastapi.testclient import TestClient
 from app.main import app
 from unittest.mock import AsyncMock, patch
+from app.models.exceptions import NombreYaUsadoException, IdYaUsadaException, TamañoExcedidoException
 from app.models.file import File
 from app.models.user import User
 from app.schemas.file_schemas import FileResponse
@@ -27,7 +28,8 @@ def test_subir_archivo():
             "file_upload": ("test.txt", io.BytesIO(b"Test"), "text/plain")
         })
 
-    archivo_response: FileResponse = FileResponse.model_validate(response.json())
+    archivo_response: FileResponse = FileResponse.model_validate(
+        response.json())
 
     assert response.status_code == 200
     assert archivo_response.archivos[0].id == archivo_falso.id
@@ -48,6 +50,7 @@ def test_subir_sin_archivo():
 
     app.dependency_overrides.clear()
 
+
 def test_subir_varios_archivos():
     app.dependency_overrides[get_current_user] = override_get_current_user
 
@@ -56,8 +59,8 @@ def test_subir_varios_archivos():
     archivo_falso: File = File(id=id, nombre_original="test.txt", tamaño_bytes="20",
                                path=f"uploads/{id}.txt", fecha_creacion="2026-01-21T01:44:31.825198", id_usuario=id, usuario=usuario_falso)
     archivo_falso2: File = File(id=id, nombre_original="test2.txt", tamaño_bytes="100",
-                               path=f"uploads/{id}.txt", fecha_creacion="2026-01-22T01:44:31.825198", id_usuario=id, usuario=usuario_falso)
-    
+                                path=f"uploads/{id}.txt", fecha_creacion="2026-01-22T01:44:31.825198", id_usuario=id, usuario=usuario_falso)
+
     archivos_falsos = [archivo_falso, archivo_falso2]
 
     with patch("app.routes.file_routes.guardar_archivo", new_callable=AsyncMock) as mock_guardar:
@@ -68,7 +71,8 @@ def test_subir_varios_archivos():
             ("file_upload", ("test2.txt", io.BytesIO(b"Test2"), "text/plain"))
         ])
 
-    archivo_response: FileResponse = FileResponse.model_validate(response.json())
+    archivo_response: FileResponse = FileResponse.model_validate(
+        response.json())
 
     assert response.status_code == 200
     for i, archivo in enumerate(archivos_falsos):
@@ -77,5 +81,76 @@ def test_subir_varios_archivos():
         assert archivo_response.archivos[i].path == archivo.path
         assert archivo_response.archivos[i].id_usuario == archivo.id_usuario
         assert archivo_response.archivos[i].nombre_usuario == usuario_falso.nombre
+
+    app.dependency_overrides.clear()
+
+
+def test_subir_archivo_nombre_usado():
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    with patch("app.routes.file_routes.guardar_archivo", new_callable=AsyncMock) as mock_guardar:
+        mock_guardar.side_effect = NombreYaUsadoException(
+            "Ya hay un archivo con ese nombre")
+
+        response = client.post(
+            "/api/files", files=[("file_upload", ("test.txt", io.BytesIO(b"Test"), "text/plain"))]
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Ya hay un archivo con ese nombre"
+
+    app.dependency_overrides.clear()
+
+
+def test_subir_archivo_id_usada():
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    with patch("app.routes.file_routes.guardar_archivo", new_callable=AsyncMock) as mock_guardar:
+        mock_guardar.side_effect = IdYaUsadaException(
+            "Ya se ha usado la ID. Vuelve a subir el archivo")
+
+        response = client.post(
+            "/api/files", files=[("file_upload", ("test.txt", io.BytesIO(b"Test"), "text/plain"))]
+        )
+
+    assert response.status_code == 409
+    assert response.json()[
+        "detail"] == "Ya se ha usado la ID. Vuelve a subir el archivo"
+
+    app.dependency_overrides.clear()
+
+
+def test_subir_archivo_id_usada():
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    with patch("app.routes.file_routes.guardar_archivo", new_callable=AsyncMock) as mock_guardar:
+        mock_guardar.side_effect = IdYaUsadaException(
+            "Ya se ha usado la ID. Vuelve a subir el archivo")
+
+        response = client.post(
+            "/api/files", files=[("file_upload", ("test.txt", io.BytesIO(b"Test"), "text/plain"))]
+        )
+
+    assert response.status_code == 409
+    assert response.json()[
+        "detail"] == "Ya se ha usado la ID. Vuelve a subir el archivo"
+
+    app.dependency_overrides.clear()
+
+
+def test_subir_archivo_tamaño_excedido():
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    with patch("app.routes.file_routes.guardar_archivo", new_callable=AsyncMock) as mock_guardar:
+        mock_guardar.side_effect = TamañoExcedidoException(
+            f"Has excedido el tamaño máximo de subida")
+
+        response = client.post(
+            "/api/files", files=[("file_upload", ("test.txt", io.BytesIO(b"Test"), "text/plain"))]
+        )
+
+    assert response.status_code == 413
+    assert response.json()[
+        "detail"] == "Has excedido el tamaño máximo de subida"
 
     app.dependency_overrides.clear()


### PR DESCRIPTION
Evitar que se repitan nombres de archivos y misma extensión.
Ya aplicaré esta medida solo para los mismos niveles de carpetas.

Fixes #31 