### PR TITLE
refactor: unificar carpetas y archivos raíz

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.routes.auth_routes import auth_router
 from app.routes.file_routes import file_router
 from app.routes.folder_routes import folder_router
 from app.routes.shared_routes import shared_router
+from app.routes.item_routes import item_router
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -32,3 +33,4 @@ app.include_router(auth_router, prefix="/auth", tags=["Auth"])
 app.include_router(file_router, prefix="/api/files", tags=["Files"])
 app.include_router(folder_router, prefix="/api/folders", tags=["Folders"])
 app.include_router(shared_router, prefix="/api/shared", tags=["Shared"])
+app.include_router(item_router, prefix="/api/v2/items", tags=["Items"])

--- a/backend/app/repositories/file_repo.py
+++ b/backend/app/repositories/file_repo.py
@@ -95,3 +95,7 @@ def get_all_files_in_folder_paginados(id_carpeta: uuid.UUID, db: Session, id_usu
         File.fecha_creacion.desc()).offset(offset).limit(limit).all()
 
     return total, archivos
+
+
+def get_files_raiz_sorted(id_usuario: uuid.UUID, db: Session) -> list[File]:
+    return db.query(File).filter(File.id_usuario == id_usuario, File.id_carpeta == None, File.fecha_eliminacion == None).order_by(File.fecha_creacion.desc()).all()

--- a/backend/app/repositories/folder_repo.py
+++ b/backend/app/repositories/folder_repo.py
@@ -100,3 +100,7 @@ def get_folders_inside_folder_paginadas(id_carpeta: uuid.UUID, id_usuario: uuid.
         Folder.fecha_creacion.desc()).offset(offset).limit(limit).all()
 
     return total, carpetas
+
+
+def get_folders_user_raiz_sorted(id_usuario: uuid.UUID, db: Session) -> list[Folder]:
+    return db.query(Folder).filter(Folder.id_usuario == id_usuario, Folder.id_carpeta == None, Folder.fecha_eliminacion == None).order_by(Folder.fecha_creacion.desc()).all()

--- a/backend/app/routes/item_routes.py
+++ b/backend/app/routes/item_routes.py
@@ -1,0 +1,61 @@
+from typing import Union
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database.db import get_db
+from app.middleware.auth_middleware import get_current_user
+from app.middleware.pagination_middleware import get_pagination
+from app.models.file import File
+from app.models.user import User
+from app.services import item_services
+from app.schemas import file_schemas, item_schemas
+
+item_router = APIRouter()
+
+
+@item_router.get("", response_model=item_schemas.PaginatedItemResponse)
+def get_items(usuario: User = Depends(get_current_user), db: Session = Depends(get_db), paginacion: tuple[int, int] = Depends(get_pagination)):
+    pagina, limite = paginacion
+
+    total, items = item_services.obtener_items_raiz_paginados(
+        usuario=usuario, db=db, pagina=pagina, limite=limite)
+
+    items_serializados: list[Union[file_schemas.FileBase,
+                                   file_schemas.File]] = []
+
+    for item in items:
+        if isinstance(item, File):
+            items_serializados.append(
+                item_schemas.FileItem(
+                    id=item.id,
+                    nombre_original=item.nombre_original,
+                    path=item.path,
+                    tamaño_bytes=item.tamaño_bytes,
+                    fecha_creacion=item.fecha_creacion,
+                    id_usuario=item.id_usuario,
+                    nombre_usuario=item.usuario.nombre,
+                    id_carpeta=item.id_carpeta,
+                    fecha_eliminacion=item.fecha_eliminacion
+                )
+            )
+        else:
+            items_serializados.append(
+                item_schemas.FolderItem(
+                    id=item.id,
+                    nombre_original=item.nombre_original,
+                    path=item.path,
+                    fecha_creacion=item.fecha_creacion,
+                    id_usuario=item.id_usuario,
+                    nombre_usuario=item.usuario.nombre,
+                    id_carpeta=item.id_carpeta,
+                    fecha_eliminacion=item.fecha_eliminacion
+                )
+            )
+
+    return {
+        "items": items_serializados,
+        "total": total,
+        "pagina": pagina,
+        "limite": limite
+    }

--- a/backend/app/schemas/item_schemas.py
+++ b/backend/app/schemas/item_schemas.py
@@ -1,0 +1,21 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from app.schemas.file_schemas import FileBase
+from app.schemas.folder_schemas import FolderBase
+
+
+class FileItem(FileBase):
+    tipo: str = "file"
+
+
+class FolderItem(FolderBase):
+    tipo: str = "folder"
+
+
+class PaginatedItemResponse(BaseModel):
+    items: list[Union[FolderItem, FileItem]]
+    total: int
+    pagina: int
+    limite: int

--- a/backend/app/services/item_services.py
+++ b/backend/app/services/item_services.py
@@ -1,0 +1,25 @@
+from typing import Union
+
+from sqlalchemy.orm import Session
+
+from app.models.file import File
+from app.models.folder import Folder
+from app.models.user import User
+from app.repositories import file_repo, folder_repo
+
+
+def obtener_items_raiz_paginados(usuario: User, db: Session, pagina: int, limite: int) -> tuple[int, list[Union[Folder, File]]]:
+    offset: int = (pagina - 1) * limite
+
+    carpetas: list[Folder] = folder_repo.get_folders_user_raiz_sorted(
+        id_usuario=usuario.id, db=db)
+    archivos: list[File] = file_repo.get_files_raiz_sorted(
+        id_usuario=usuario.id, db=db)
+
+    items: list[Union[Folder, File]] = carpetas + archivos
+
+    total: int = len(items)
+
+    items_paginados = items[offset: offset + limite]
+
+    return total, items_paginados


### PR DESCRIPTION
Refactor necesario para facilitar la paginación y los filtros a futuro 
(no borrar endpoints antiguos!!!)